### PR TITLE
Fix private variable declaration in ResourceQuery, update rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
 require 'rake'
 require 'rake/testtask'
 require 'rake/clean'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'fileutils'
 include FileUtils
 
-require 'tools/rakehelp'
+require_relative 'tools/rakehelp'
 
 $version  = IO.read('VERSION').strip
 $name     = 'activerdf'
@@ -28,8 +28,8 @@ begin
   require 'jeweler'
   Jeweler::Tasks.new do |gemspec|
     gemspec.name = 'activerdf'
-    gemspec.summary = 'Offers object-oriented access to RDF (with adapters to several datastores).' 
-    gemspec.description = gemspec.summary 
+    gemspec.summary = 'Offers object-oriented access to RDF (with adapters to several datastores).'
+    gemspec.description = gemspec.summary
     gemspec.authors = ['Michael Diamond', 'Eyal Oren', 'The Talia Team']
     gemspec.email = 'michael@thinknasium.org'
     gemspec.homepage = 'http://www.activerdf.org'

--- a/lib/active_rdf/model/resource_query.rb
+++ b/lib/active_rdf/model/resource_query.rb
@@ -16,6 +16,7 @@ module ActiveRDF
   #   ResourceQuery.new(TEST::Person).age(27).eye(LocalizedString('blue','en')).execute  # chain multiple properties together, ANDing restrictions
   class ResourceQuery
     include Helpers
+    attr :type
     private(:type)
 
     def initialize(type,context = nil)


### PR DESCRIPTION
Fixed declaration of type as private before variable declaration in the ResourceQuery class, made some updates to the rakefile based on deprecation notices. The gem now compiles and loads properly, although the example on activerdf.org hung during an http request during the Resource.new command, so there' may be other things that still need fixing
